### PR TITLE
Bump min version_requirement for Puppet + deps

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,17 +10,17 @@
   "dependencies": [
     {
       "name": "saz/ssh",
-      "version_requirement": ">= 2.5.0 < 3.0.0"
+      "version_requirement": ">= 2.9.1 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.1.0"
+      "version_requirement": ">=4.6.0 < 5.0.0"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.5.0 <5.0.0"
+      "version_requirement": ">=3.8.7 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata