### PR TITLE
Add a default password authentication setting

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -24,6 +24,7 @@ Manage SFTP Jails
 The following parameters are available in the `sftp_jail` class:
 
 * [`chroot_base`](#chroot_base)
+* [`password_authentication`](#password_authentication)
 
 ##### <a name="chroot_base"></a>`chroot_base`
 
@@ -32,6 +33,15 @@ Data type: `Stdlib::Absolutepath`
 All jails are located in this directory.
 
 Default value: `'/chroot'`
+
+##### <a name="password_authentication"></a>`password_authentication`
+
+Data type: `Enum['yes', 'no']`
+
+Default Password Authentication setting for SFTP jails. This will only
+impact SFTP users which are put in a chroot jail by this module.
+
+Default value: `'no'`
 
 ## Defined types
 
@@ -123,11 +133,12 @@ Default value: `$group`
 
 ##### <a name="password_authentication"></a>`password_authentication`
 
-Data type: `Any`
+Data type: `Enum['yes', 'no']`
 
-OpenSSH Password Authentication
+Can the user login with a password? Public key authentication is generally
+recommended and has to be configured outside of the scope of this module.
 
-Default value: `'no'`
+Default value: `$sftp_jail::password_authentication`
 
 ### <a name="sftp_jailuser"></a>`sftp_jail::user`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,8 +3,13 @@
 # @param chroot_base
 #   All jails are located in this directory.
 #
+# @param password_authentication
+#   Default Password Authentication setting for SFTP jails. This will only
+#   impact SFTP users which are put in a chroot jail by this module.
+#
 class sftp_jail (
-  Stdlib::Absolutepath $chroot_base = '/chroot',
+  Stdlib::Absolutepath $chroot_base             = '/chroot',
+  Enum['yes', 'no']    $password_authentication = 'no',
 ) {
   file { $chroot_base:
     ensure => 'directory',

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -47,14 +47,15 @@
 #   Useful for shared jails. Defaults to the value of `group`.
 #
 # @param password_authentication
-#   OpenSSH Password Authentication
+#   Can the user login with a password? Public key authentication is generally
+#   recommended and has to be configured outside of the scope of this module.
 #
 define sftp_jail::jail (
-  $jail_name               = $name,
-  $user                    = $name,
-  $group                   = $user,
-  $match_group             = $group,
-  $password_authentication = 'no',
+  $jail_name                                 = $name,
+  $user                                      = $name,
+  $group                                     = $user,
+  $match_group                               = $group,
+  Enum['yes', 'no'] $password_authentication = $sftp_jail::password_authentication,
 ) {
   include sftp_jail
   $jail_base = "${sftp_jail::chroot_base}/${jail_name}"

--- a/spec/acceptance/sftp_jail_spec.rb
+++ b/spec/acceptance/sftp_jail_spec.rb
@@ -4,6 +4,7 @@ describe 'basic and shared SFTP jails' do
   it 'sets up the defaults' do
     pp = <<-EOS
       class {'ssh': } ->
+      class {'sftp_jail': } ->
       group { ['alice','bob','carol','dave','shared1']:
         ensure => 'present',
       } ->

--- a/spec/classes/sftp_jail_init_spec.rb
+++ b/spec/classes/sftp_jail_init_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'sftp_jail' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      context 'with all defaults' do
+        it { is_expected.to compile }
+        it 'manages chroot folder' do
+          is_expected.to contain_file('/chroot').with(
+            'ensure' => 'directory',
+            'owner'  => 'root',
+            'group'  => 'root',
+            'mode'   => '0755'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/sftp_jail_jail_spec.rb
+++ b/spec/defines/sftp_jail_jail_spec.rb
@@ -57,5 +57,37 @@ describe 'sftp_jail::jail' do
                                                                          })
       end
     end
+    
+    context "PasswordAuthentication on #{os}" do
+      let :facts do
+        facts
+      end
+      let :pre_condition do
+        'include ssh, sftp_jail'
+      end
+      let :params do
+        {
+          user: 'alice',
+          group: 'alice',
+          password_authentication: 'yes'
+        }
+      end
+      let :title do
+        'test2'
+      end
+
+      it 'allows PasswordAuthentication for the user alice' do
+        is_expected.to contain_ssh__server__match_block('alice').with(
+          'type' => 'Group',
+          'options' => {
+            'ChrootDirectory'        => '/chroot/test2',
+            'ForceCommand'           => 'internal-sftp',
+            'PasswordAuthentication' => 'yes',
+            'AllowTcpForwarding'     => 'no',
+            'X11Forwarding'          => 'no'
+          }
+        )
+      end
+    end
   end
 end

--- a/spec/defines/sftp_jail_jail_spec.rb
+++ b/spec/defines/sftp_jail_jail_spec.rb
@@ -7,7 +7,7 @@ describe 'sftp_jail::jail' do
         facts
       end
       let :pre_condition do
-        'include ssh'
+        'include ssh, sftp_jail'
       end
       let :params do
         {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR enables you to pick your default for password authentication. This is done by passing a value to `$sftp_jail::password_authentication`.