### PR TITLE
Make $sftp_jail::user::jail a required parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -157,9 +157,16 @@ sftp_jail::user{'bob':
 
 The following parameters are available in the `sftp_jail::user` defined type:
 
+* [`jail`](#jail)
 * [`user`](#user)
 * [`group`](#group)
-* [`jail`](#jail)
+
+##### <a name="jail"></a>`jail`
+
+Data type: `Any`
+
+The path of the jail's base directory, such as `/chroot/myjail`. Do not
+include a trailing slash.
 
 ##### <a name="user"></a>`user`
 
@@ -177,13 +184,4 @@ Data type: `Any`
 The group that will own the corresponding home directory in the jail.
 
 Default value: `$name`
-
-##### <a name="jail"></a>`jail`
-
-Data type: `Any`
-
-The path of the jail's base directory, such as `/chroot/myjail`. Do not
-include a trailing slash.
-
-Default value: ``undef``
 

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -14,6 +14,10 @@
 #     jail  => '/chroot/myjail',
 #   }
 #
+# @param jail
+#   The path of the jail's base directory, such as `/chroot/myjail`. Do not
+#   include a trailing slash.
+#
 # @param user
 #   The username that will own the corresponding home directory in the jail,
 #   giving the user a place to land.
@@ -21,14 +25,10 @@
 # @param group
 #   The group that will own the corresponding home directory in the jail.
 #
-# @param jail
-#   The path of the jail's base directory, such as `/chroot/myjail`. Do not
-#   include a trailing slash.
-#
 define sftp_jail::user (
+  $jail,
   $user  = $name,
   $group = $name,
-  $jail =  undef,
 ) {
   file { "${jail}/home/${user}":
     ensure => 'directory',


### PR DESCRIPTION
#### Pull Request (PR) description

`$sftp_jail::user::jail` is a required parameter and it is now more obvious.