### PR TITLE
the owning group of a users home directory defaults to $user, not to $name

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -183,5 +183,5 @@ Data type: `Any`
 
 The group that will own the corresponding home directory in the jail.
 
-Default value: `$name`
+Default value: `$user`
 

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -28,7 +28,7 @@
 define sftp_jail::user (
   $jail,
   $user  = $name,
-  $group = $name,
+  $group = $user,
 ) {
   file { "${jail}/home/${user}":
     ensure => 'directory',


### PR DESCRIPTION
#### Pull Request (PR) description

**Warning**: This PR is not backwards compatible. But is most situations, it will not matter.

This is an edge case.
The default behavior for group changes slightly:
When creating user and passing a value to $user, while not
passing a value to $group, will now result in $group = $user, instead of
$group = $name.