### PR TITLE
Allow jail creation without specifying a user

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -101,7 +101,7 @@ Data type: `Any`
 The user that will own the corresponding home directory in the jail, giving
 the user a place to land. Also sets user ownership for `/incoming`.
 
-Default value: ``undef``
+Default value: `$name`
 
 ##### <a name="group"></a>`group`
 

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -51,7 +51,7 @@
 #
 define sftp_jail::jail (
   $jail_name               = $name,
-  $user                    = undef,
+  $user                    = $name,
   $group                   = $user,
   $match_group             = $group,
   $password_authentication = 'no',


### PR DESCRIPTION
#### Pull Request (PR) description

You can create a jail without passing a $user parameter, it will use the
resources $name as $user. This is useful, when $jail_name and $user shall
have the same value.