### PR TITLE
Add Debian 11 and Ubuntu 20.04 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -39,13 +39,15 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     }
   ]


### PR DESCRIPTION
Add Debian 11 and Ubuntu 20.04 to the supported operating systems.