### PR TITLE
move creation of user home from jail.pp to user.pp

### DIFF
--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -74,11 +74,9 @@ define sftp_jail::jail (
     mode   => '0775',
   }
 
-  file { "${jail_base}/home/${user}":
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
-    mode   => '0755',
+  sftp_jail::user { $user:
+    jail  => $jail_base,
+    group => $group,
   }
 
   ssh::server::match_block { $match_group:


### PR DESCRIPTION
Both jail.pp and user.pp do create user home. jail.pp creates a user home
by calling sftp_jail::user instead of creating the home it self. This
removes duplicate code.

This change prepares the addition of a new feature: adding sub
directories into user homes. Without this change, the new feature would
have to be implemented twice.
