### PR TITLE
Drop End of Life Redhat 7 and Centos 7/8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -35,8 +34,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "9"
       ]
     },


### PR DESCRIPTION
#### Pull Request (PR) description
Remove Redhat 7 and CentOS 7/8 as these are now End of Life

